### PR TITLE
Add ORDER BY to sync queries

### DIFF
--- a/pkg/graph/postgres/factory.go
+++ b/pkg/graph/postgres/factory.go
@@ -208,6 +208,9 @@ func (p *pgxGraph) init(ctx context.Context, syncTable string, sequenceTable str
 		p.Name,
 		p.Table.KeyField,
 		p.Table.VersionField)
+	if pf := p.Table.PriorityField; pf != "" {
+		p.syncQuery += " ORDER BY model." + pf
+	}
 	p.syncSequenceQuery = fmt.Sprintf("SELECT child, sequence FROM %s WHERE model = '%s' AND peer = $1 AND id = $2", sequenceTable, p.Name)
 	p.statusStatement = fmt.Sprintf("INSERT INTO %s (peer, model, id, version, status, status_message) VALUES ($1, '%s', $2, $3, $4, $5) ON CONFLICT (peer, model, id) DO UPDATE SET version = EXCLUDED.version, status = EXCLUDED.status, status_message = EXCLUDED.status_message",
 		syncTable,

--- a/pkg/graph/postgres/factory_test.go
+++ b/pkg/graph/postgres/factory_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Factory", func() {
 			Expect(artists.model.readQuery).To(Equal("SELECT name, version FROM syncd.artists WHERE id = $1 FOR SHARE"))
 			Expect(artists.model.lockQuery).To(Equal("SELECT version FROM syncd.artists WHERE id = $1 FOR UPDATE"))
 			//Expect(artists.model.updateStatement).To(Equal("UPDATE syncd.artists SET name = $2, version = $3 WHERE id = $1"))
-			Expect(artists.model.insertStatement).To(Equal("INSERT INTO syncd.artists (id, name, version) VALUES ($1, $2, $3)"))
+			Expect(artists.model.insertStatement).To(Equal("INSERT INTO syncd.artists (id, name, version) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, version = EXCLUDED.version"))
 			Expect(artists.model.deleteStatement).To(BeEmpty())
 		})
 
@@ -428,7 +428,7 @@ var _ = Describe("Factory", func() {
 			Expect(performers.model.readQuery).To(Equal("SELECT name, label, version FROM syncd.performers WHERE id = $1 FOR SHARE"))
 			Expect(performers.model.lockQuery).To(Equal("SELECT version FROM syncd.performers WHERE id = $1 FOR UPDATE"))
 			//Expect(performers.model.updateStatement).To(Equal("UPDATE syncd.performers SET name = $2, label = $3, version = $4 WHERE id = $1"))
-			Expect(performers.model.insertStatement).To(Equal("INSERT INTO syncd.performers (id, name, label, version) VALUES ($1, $2, $3, $4)"))
+			Expect(performers.model.insertStatement).To(Equal("INSERT INTO syncd.performers (id, name, label, version) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, label = EXCLUDED.label, version = EXCLUDED.version"))
 			Expect(performers.model.deleteStatement).To(BeEmpty())
 		})
 
@@ -492,7 +492,7 @@ var _ = Describe("Factory", func() {
 			By("generating a read query")
 			Expect(performances.readQuery).To(Equal("SELECT sequence, song FROM syncd.performances WHERE performer = $1"))
 			Expect(performances.lockQuery).To(BeEmpty())
-			Expect(performances.insertStatement).To(Equal("INSERT INTO syncd.performances (performer, sequence, song) VALUES ($1, $2, $3)"))
+			Expect(performances.insertStatement).To(Equal("INSERT INTO syncd.performances (performer, sequence, song) VALUES ($1, $2, $3) ON CONFLICT (performer, sequence) DO UPDATE SET song = EXCLUDED.song"))
 			Expect(performances.deleteStatement).To(BeEmpty())
 			//Expect(performances.updateStatement).To(BeEmpty())
 		})


### PR DESCRIPTION
Support for field-based ordering of sync is supported by the [table struct](https://github.com/raft-tech/syncd/blob/2b1b1743bdd9dc1182fb38fa5a5bcc4386757cb1/pkg/graph/types.go#L60) the [graph config spec](https://github.com/raft-tech/syncd/blob/2b1b1743bdd9dc1182fb38fa5a5bcc4386757cb1/cmd/helpers/graph.go#L130), but it is not implemented by the sync query.