### PR TITLE
Mitigate OpenSSF Scorecard Findings

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+permissions: read-all
+
 jobs:
   Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -14,9 +14,9 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           cache: true
           go-version-file: 'go.mod'
@@ -28,9 +28,9 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           cache: true
           go-version-file: 'go.mod'
@@ -43,30 +43,30 @@ jobs:
     runs-on: ubuntu-latest
     if:  github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up QEMU  # Virtualization tool  
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
     
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push syncd snapshot
         if: startsWith(github.ref, 'refs/tags/v') != true
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           push: true
           tags: rafttech/syncd:${{ github.sha }}
 
       - name: Build and push things snapshot
         if: startsWith(github.ref, 'refs/tags/v') != true
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           file: examples/things/app/Dockerfile
           push: true
@@ -78,14 +78,14 @@ jobs:
 
       - name: Build and push syncd release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           push: true
           tags: rafttech/syncd:${{ env.RELEASE_VERSION }}
 
       - name: Build and push things release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           file: examples/things/app/Dockerfile
           push: true

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Build an image from Dockerfile
         run: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,8 +11,7 @@ on:
   schedule:
     - cron: '40 15 * * 4'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.20 as BUILD
+FROM golang:1.20@sha256:bdd178660145acd8edcc076bec4c92888988a6556de7b3363a30cdea87b7086b as BUILD
 COPY go.mod go.sum /src/
 WORKDIR /src
 RUN go mod download
 COPY . /src
 RUN CGO_ENABLED=0 go build -o /syncd /src/main.go
 
-FROM golang:1.20 AS gRPC
+FROM golang:1.20@sha256:bdd178660145acd8edcc076bec4c92888988a6556de7b3363a30cdea87b7086b AS gRPC
 ARG PROTOC_VERSION=23.4
 RUN apt-get update && apt-get install --no-install-recommends -y \
     unzip=6.0-26+deb11u1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 RUN wget -O /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
     && unzip -d /usr/local /tmp/protoc.zip bin/protoc \
-    && rm -rf /tmp/protoc.zip
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28; \
-    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+    && rm -rf /tmp/protoc.zip \
+    # protoc-gen-go@v1.28
+    # protoc-gen-go-grpc@v1.2.0
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@32051b4f86e54c2142c7c05362c6e96ae3454a1c; \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@cdee119ee21e61eef7093a41ba148fa83585e143
 WORKDIR /src
 ENTRYPOINT ["protoc"]
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ internal/api/syncd.pb.go internal/api/syncd_grpc.pb.go: api/syncd.proto
 server.crt server.key:
 	openssl req -x509 -newkey rsa:2048 -keyout server.key -out server.crt -days 30 -nodes \
 		-subj "/C=US/CN=syncd" \
-		-addext "subjectAltName=DNS:syncd"
+		-extensions "subjectAltName=DNS:syncd"
 
 # PostgreSQL Instances
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ internal/api/syncd.pb.go internal/api/syncd_grpc.pb.go: api/syncd.proto
 server.crt server.key:
 	openssl req -x509 -newkey rsa:2048 -keyout server.key -out server.crt -days 30 -nodes \
 		-subj "/C=US/CN=syncd" \
-		-extensions "subjectAltName=DNS:syncd"
+		-addext "subjectAltName=DNS:syncd"
 
 # PostgreSQL Instances
 

--- a/charts/syncd/templates/client/deployment.yaml
+++ b/charts/syncd/templates/client/deployment.yaml
@@ -25,11 +25,6 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- else }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- end }}
       securityContext:
         {{- with .Values.securityContext }}

--- a/charts/syncd/templates/server/deployment.yaml
+++ b/charts/syncd/templates/server/deployment.yaml
@@ -24,11 +24,6 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- else }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- end }}
       securityContext:
         {{- with .Values.securityContext }}

--- a/examples/things/app/Dockerfile
+++ b/examples/things/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as BUILD
+FROM golang:1.20@sha256:bdd178660145acd8edcc076bec4c92888988a6556de7b3363a30cdea87b7086b as BUILD
 COPY go.mod go.sum /src/
 WORKDIR /src
 RUN go mod download


### PR DESCRIPTION
# Why was this done?
This work was done to mitigate findings discovered during OpenSSF Scorecard scanning.

# What's Included?
- updates to Dockerfile base images to include image SHA digest
- updates to Github Actions Workflows to have  `read-only` permissions by default
- removed duplicate templating in `deplyoment.yaml` Helm files

